### PR TITLE
Fix type definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,6 +2,14 @@
 import {Plugin, Processor} from 'unified'
 import {Options} from 'mdast-util-to-hast'
 
-declare const remark2rehype: Plugin<[Options?] | [Processor?, Options?]>
+type Settings =
+  | [Options?]
+  | {
+      length: number
+      0?: Processor
+      1?: Options
+    }
+
+declare const remark2rehype: Plugin<Settings>
 
 export = remark2rehype

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,14 +2,11 @@
 import {Plugin, Processor} from 'unified'
 import {Options} from 'mdast-util-to-hast'
 
-type Settings =
-  | [Options?]
-  | {
-      length: number
-      0?: Processor
-      1?: Options
-    }
+interface Settings extends Array<any> {
+  0?: Processor
+  1?: Options
+}
 
-declare const remark2rehype: Plugin<Settings>
+declare const remark2rehype: Plugin<[Options?] | Settings>
 
 export = remark2rehype


### PR DESCRIPTION
This PR fixes #16 

*Tuple Type* is added in TypeScript 3.1

This causes the error on #16 because type definition `[Processor?, Options?]` is treated as Tuple Type

refert: https://www.typescriptlang.org/docs/handbook/2/objects.html#tuple-types