### PR TITLE
Add docs for `footnoteLabelTagName`, `footnoteLabelProperties`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -259,7 +259,7 @@ choice of css.
 > 👉 **Note**: this option affects footnotes.
 > Footnotes are not specified by CommonMark.
 > They are supported by GitHub, so they can be enabled by using the utility
-> [`mdast-util-gfm`][mdast-util-gfm].
+> [`remark-gfm`][remark-gfm].
 
 ###### `options.footnoteLabelProperties`
 
@@ -273,7 +273,7 @@ either no class or no id, or an empty object to have none.
 > 👉 **Note**: this option affects footnotes.
 > Footnotes are not specified by CommonMark.
 > They are supported by GitHub, so they can be enabled by using the utility
-> [`mdast-util-gfm`][mdast-util-gfm].
+> [`remark-gfm`][remark-gfm].
 
 ###### `options.footnoteBackLabel`
 

--- a/readme.md
+++ b/readme.md
@@ -258,7 +258,7 @@ choice of css.
 
 > 👉 **Note**: this option affects footnotes.
 > Footnotes are not specified by CommonMark.
-> They are supported by GitHub, so they can be enabled by using the utility
+> They are supported by GitHub, so they can be enabled by using the plugin
 > [`remark-gfm`][remark-gfm].
 
 ###### `options.footnoteLabelProperties`
@@ -272,7 +272,7 @@ either no class or no id, or an empty object to have none.
 
 > 👉 **Note**: this option affects footnotes.
 > Footnotes are not specified by CommonMark.
-> They are supported by GitHub, so they can be enabled by using the utility
+> They are supported by GitHub, so they can be enabled by using the plugin
 > [`remark-gfm`][remark-gfm].
 
 ###### `options.footnoteBackLabel`

--- a/readme.md
+++ b/readme.md
@@ -250,6 +250,31 @@ Change it when the markdown is not in English.
 > They are supported by GitHub, so they can be enabled by using the remark
 > plugin [`remark-gfm`][remark-gfm].
 
+###### `options.footnoteLabelTagName`
+
+HTML tag to use for the footnote label (`string`, default: `h2`).
+Can be changed to match your document structure and play well with your
+choice of css.
+
+> 👉 **Note**: this option affects footnotes.
+> Footnotes are not specified by CommonMark.
+> They are supported by GitHub, so they can be enabled by using the utility
+> [`mdast-util-gfm`][mdast-util-gfm].
+
+###### `options.footnoteLabelProperties`
+
+Properties to use on the footnote label (`object`, default: `{id:
+'footnote-label', className: ['sr-only']}`).
+A `sr-only` class is added by default to hide this from sighted users.
+Change it to make the label visible, or add classes for other purposes.
+Provide an object with no `className` or no `id` to have a footnote label with
+either no class or no id, or an empty object to have none.
+
+> 👉 **Note**: this option affects footnotes.
+> Footnotes are not specified by CommonMark.
+> They are supported by GitHub, so they can be enabled by using the utility
+> [`mdast-util-gfm`][mdast-util-gfm].
+
 ###### `options.footnoteBackLabel`
 
 Label to use from backreferences back to their footnote call (`string`, default:


### PR DESCRIPTION
This is to keep the doc in sync with mdast-util-to-hast.

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Copied the content from new content from the current mdast-util-to-hast readme.md.

<!--do not edit: pr-->
