### PR TITLE
Fix to turn of `this` error introduced in TS 4.9

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,9 @@ const remarkRehype =
   (
     function (destination, options) {
       return destination && 'run' in destination
+        // @ts-expect-error TS4.9 cannot infer `this` type
         ? bridge(destination, options)
+        // @ts-expect-error TS4.9 cannot infer `this` type
         : mutate(destination || options)
     }
   )


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I tried a few combinations of adding `@this {import('unified').Processor}` annotations to the plugin, as well as explicitly binding `bridge.bind(this)`.
Neither appeared to work, temporarily ignore the error.
Suggestions on a solution that gets TS to recognize `this` are welcome.

/cc @remcohaszing 

<!--do not edit: pr-->
