### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,10 +38,10 @@ const remarkRehype =
   (
     function (destination, options) {
       return destination && 'run' in destination
-        // @ts-expect-error TS4.9 cannot infer `this` type
-        ? bridge(destination, options)
-        // @ts-expect-error TS4.9 cannot infer `this` type
-        : mutate(destination || options)
+        ? // @ts-expect-error TS4.9 cannot infer `this` type
+          bridge(destination, options)
+        : // @ts-expect-error TS4.9 cannot infer `this` type
+          mutate(destination || options)
     }
   )
 

--- a/package.json
+++ b/package.json
@@ -36,25 +36,25 @@
     "index.js"
   ],
   "dependencies": {
-    "@types/hast": "^2.0.0",
-    "@types/mdast": "^3.0.0",
-    "mdast-util-to-hast": "^12.1.0",
-    "unified": "^10.0.0"
+    "@types/hast": "^2.3.4",
+    "@types/mdast": "^3.0.10",
+    "mdast-util-to-hast": "^12.3.0",
+    "unified": "^10.1.2"
   },
   "devDependencies": {
-    "@types/tape": "^4.0.0",
-    "c8": "^7.0.0",
-    "prettier": "^2.0.0",
-    "rehype-stringify": "^9.0.0",
+    "@types/tape": "^4.13.2",
+    "c8": "^7.12.0",
+    "prettier": "^2.8.3",
+    "rehype-stringify": "^9.0.3",
     "remark-cli": "^11.0.0",
-    "remark-parse": "^10.0.0",
-    "remark-preset-wooorm": "^9.0.0",
-    "remark-stringify": "^10.0.0",
-    "rimraf": "^3.0.0",
-    "tape": "^5.0.0",
-    "type-coverage": "^2.0.0",
-    "typescript": "^4.0.0",
-    "xo": "^0.51.0"
+    "remark-parse": "^10.0.1",
+    "remark-preset-wooorm": "^9.1.0",
+    "remark-stringify": "^10.0.2",
+    "rimraf": "^4.1.2",
+    "tape": "^5.6.3",
+    "type-coverage": "^2.24.1",
+    "typescript": "^4.9.5",
+    "xo": "^0.53.1"
   },
   "scripts": {
     "build": "rimraf \"lib/**/*.d.ts\" \"*.d.ts\" && tsc && type-coverage",


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Upgrade project dependencies to latest version. Since a new version of `mdast-util-to-hast` is released, and it contains changed regarding the `State` it is convenient to upgrade this module to prevent conflict between two versions and prevent unexpected issues.

Also, I removed `package.json` from dependencies since it has no use in the package and it is deprecated by author.

<!--do not edit: pr-->
