### PR TITLE
Fix plugin output type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ import {toHast} from 'mdast-util-to-hast'
  *   Options passed to `mdast-util-to-hast`.
  */
 const remarkRehype =
-  /** @type {(import('unified').Plugin<[Processor, Options?]|[null|undefined, Options?]|[Options]|[], MdastRoot>)} */
+  /** @type {(import('unified').Plugin<[Processor, Options?]|[null|undefined, Options?]|[Options]|[], MdastRoot, HastRoot>)} */
   (
     function (destination, options) {
       return destination && 'run' in destination


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes
#### Current
Plugin output type defaults to the input type which is `HastRoot`

#### Expected
Plugin output type should be `MdastRoot` which corresponds to the toHast return type.

#### Change
Plugin output type set to `HastRoot` instead of defaulting to the input type `MdastRoot`.

<!--do not edit: pr-->
